### PR TITLE
Deploy spatial rebalancing

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -56,6 +56,19 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	@NotNull
 	public RebalancingTargetCalculatorType rebalancingTargetCalculatorType = RebalancingTargetCalculatorType.EstimatedDemand;
 
+
+	public enum TargetCoefficientSource {
+		Static, FromZoneAttribute, FromZoneAttributeOrStatic
+	}
+
+	@Parameter
+	@Comment("Defines whether the alpha and beta of the target function should be"
+			+ " [Static] or [FromZoneAttribute] in which case alpha and beta can be provided per zone as an attribute."
+			+ " [FromZoneAttributeOrStatic] will fall back to the static coefficients if no attribute is found for a given zone."
+			+ " Use " + MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_ALPHA + " and " + MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_BETA
+			+ " to set values accordingly.")
+	public TargetCoefficientSource targetCoefficientSource = TargetCoefficientSource.Static;
+
 	public enum ZonalDemandEstimatorType {PreviousIterationDemand, None}
 
 	@Parameter

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDrtDemandEstimatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDrtDemandEstimatorTest.java
@@ -199,9 +199,9 @@ public class PreviousIterationDrtDemandEstimatorTest {
 		network.addNode(b);
 
 		Link ab = network.getFactory().createLink(Id.createLinkId("link_1"), a, b);
-		Link bc = network.getFactory().createLink(Id.createLinkId("link_2"), b, a);
+		Link ba = network.getFactory().createLink(Id.createLinkId("link_2"), b, a);
 		network.addLink(ab);
-		network.addLink(bc);
+		network.addLink(ba);
 		return network;
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyTest.java
@@ -1,0 +1,279 @@
+package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
+
+import com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.prep.PreparedPolygon;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.common.zones.Zone;
+import org.matsim.contrib.common.zones.ZoneImpl;
+import org.matsim.contrib.common.zones.ZoneSystem;
+import org.matsim.contrib.common.zones.ZoneSystemImpl;
+import org.matsim.contrib.drt.analysis.zonal.MostCentralDrtZoneTargetLinkSelector;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
+import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.PreviousIterationDrtDemandEstimator;
+import org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator.DemandEstimatorAsTargetCalculator;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.fleet.*;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.utils.geometry.GeometryUtils;
+
+import java.util.*;
+
+public class MinCostFlowRebalancingStrategyTest {
+
+    private static final int ESTIMATION_PERIOD = 1800;
+
+    private final Network network = createNetwork();
+
+    private final Link link1 = network.getLinks().get(Id.createLinkId("link_1"));
+    private final Link link2 = network.getLinks().get(Id.createLinkId("link_2"));
+
+    private final Zone zone1 = new ZoneImpl(
+            Id.create("zone_1", Zone.class),
+            new PreparedPolygon(GeometryUtils.createGeotoolsPolygon(
+                    List.of(
+                            new Coord(0, 0),
+                            new Coord(0, 500),
+                            new Coord(500, 500),
+                            new Coord(500, 0),
+                            new Coord(0, 0)
+                    ))), "dummy");
+
+    private final Zone zone2 = new ZoneImpl(
+            Id.create("zone_2", Zone.class),
+            new PreparedPolygon(GeometryUtils.createGeotoolsPolygon(
+                    List.of(
+                            new Coord(500, 0),
+                            new Coord(500, 500),
+                            new Coord(1000, 500),
+                            new Coord(1000, 0),
+                            new Coord(500, 0)
+                    ))), "dummy");
+
+    private final ZoneSystem zonalSystem = new ZoneSystemImpl(List.of(zone1, zone2), coord -> {
+        if (coord == link1.getToNode().getCoord()) {
+            return Optional.of(zone1);
+        } else if (coord == link2.getToNode().getCoord()) {
+            return Optional.of(zone2);
+        } else {
+            throw new RuntimeException();
+        }
+    }, network);
+
+
+    @Test
+    void testEmptyDemandAndTarget() {
+        PreviousIterationDrtDemandEstimator estimator = createEstimator();
+        DemandEstimatorAsTargetCalculator targetCalculator = new DemandEstimatorAsTargetCalculator(estimator, ESTIMATION_PERIOD);
+
+        RebalancingParams rebalancingParams = new RebalancingParams();
+        MinCostFlowRebalancingStrategyParams minCostFlowRebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
+        minCostFlowRebalancingStrategyParams.targetAlpha = 1.;
+        minCostFlowRebalancingStrategyParams.targetBeta = 0.;
+        rebalancingParams.addParameterSet(minCostFlowRebalancingStrategyParams);
+
+        AggregatedMinCostRelocationCalculator relocationCalculator = new AggregatedMinCostRelocationCalculator(new MostCentralDrtZoneTargetLinkSelector(zonalSystem));
+        MinCostFlowRebalancingStrategy strategy = new MinCostFlowRebalancingStrategy(targetCalculator,
+                zonalSystem, createEmptyFleet(), relocationCalculator, rebalancingParams);
+
+        Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
+        List<RebalancingStrategy.Relocation> relocations = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations.isEmpty());
+    }
+
+    @Test
+    void testDemandWithoutSurplus() {
+        PreviousIterationDrtDemandEstimator estimator = createEstimator();
+        DemandEstimatorAsTargetCalculator targetCalculator = new DemandEstimatorAsTargetCalculator(estimator, ESTIMATION_PERIOD);
+
+        RebalancingParams rebalancingParams = new RebalancingParams();
+        MinCostFlowRebalancingStrategyParams minCostFlowRebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
+        minCostFlowRebalancingStrategyParams.targetAlpha = 1.;
+        minCostFlowRebalancingStrategyParams.targetBeta = 0.;
+        rebalancingParams.addParameterSet(minCostFlowRebalancingStrategyParams);
+
+        AggregatedMinCostRelocationCalculator relocationCalculator = new AggregatedMinCostRelocationCalculator(new MostCentralDrtZoneTargetLinkSelector(zonalSystem));
+        MinCostFlowRebalancingStrategy strategy = new MinCostFlowRebalancingStrategy(targetCalculator,
+                zonalSystem, createEmptyFleet(), relocationCalculator, rebalancingParams);
+
+        //time bin 0-1800
+        estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(200, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(500, link2, TransportMode.drt));
+        estimator.handleEvent(departureEvent(1500, link1, TransportMode.drt));
+        estimator.reset(1);
+
+        Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
+        List<RebalancingStrategy.Relocation> relocations = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations.isEmpty());
+    }
+
+    @Test
+    void testDemandWithSurplus() {
+        PreviousIterationDrtDemandEstimator estimator = createEstimator();
+        DemandEstimatorAsTargetCalculator targetCalculator = new DemandEstimatorAsTargetCalculator(estimator, ESTIMATION_PERIOD);
+
+        RebalancingParams rebalancingParams = new RebalancingParams();
+        MinCostFlowRebalancingStrategyParams minCostFlowRebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
+        minCostFlowRebalancingStrategyParams.targetAlpha = 1.;
+        minCostFlowRebalancingStrategyParams.targetBeta = 0.;
+        rebalancingParams.addParameterSet(minCostFlowRebalancingStrategyParams);
+
+        AggregatedMinCostRelocationCalculator relocationCalculator = new AggregatedMinCostRelocationCalculator(new MostCentralDrtZoneTargetLinkSelector(zonalSystem));
+        MinCostFlowRebalancingStrategy strategy = new MinCostFlowRebalancingStrategy(targetCalculator,
+                zonalSystem, createEmptyFleet(), relocationCalculator, rebalancingParams);
+
+        // 3 expected trips in zone 1
+        estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(200, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(300, link1, TransportMode.drt));
+        // 1 expected trip in zone 2
+        estimator.handleEvent(departureEvent(100, link2, TransportMode.drt));
+        estimator.reset(1);
+
+        Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
+
+        // 4 vehicles in zone 1 (surplus = 1)
+        List<DvrpVehicle> rebalanceableVehiclesZone1 = new ArrayList<>();
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a1", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a2", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a3", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a4", DvrpVehicle.class), link1));
+        rebalanceableVehicles.put(zone1, rebalanceableVehiclesZone1);
+
+        List<RebalancingStrategy.Relocation> relocations = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations.size()).isEqualTo(1);
+        Assertions.assertThat(relocations.getFirst().link.getId()).isEqualTo(link2.getId());
+
+        rebalanceableVehicles.clear();
+
+        // 5 vehicles in zone 1 (surplus = 2)
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a1", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a2", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a3", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a4", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a5", DvrpVehicle.class), link1));
+        rebalanceableVehicles.put(zone1, rebalanceableVehiclesZone1);
+
+        //set alpha to 2 -> send two vehicles to zone 2
+        minCostFlowRebalancingStrategyParams.targetAlpha = 2.;
+        List<RebalancingStrategy.Relocation> relocations2 = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations2.size()).isEqualTo(2);
+        Assertions.assertThat(relocations2.getFirst().link.getId()).isEqualTo(link2.getId());
+        Assertions.assertThat(relocations2.getLast().link.getId()).isEqualTo(link2.getId());
+    }
+
+    @Test
+    void testDemandWithSurplusZoneBasedTargetRates() {
+
+        // set attributes
+        zone1.getAttributes().putAttribute(MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_ALPHA, 0.);
+        zone1.getAttributes().putAttribute(MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_BETA, 0.);
+        zone2.getAttributes().putAttribute(MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_ALPHA, 1.);
+        zone2.getAttributes().putAttribute(MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_BETA, 0.);
+
+
+        PreviousIterationDrtDemandEstimator estimator = createEstimator();
+        DemandEstimatorAsTargetCalculator targetCalculator = new DemandEstimatorAsTargetCalculator(estimator, ESTIMATION_PERIOD);
+
+        RebalancingParams rebalancingParams = new RebalancingParams();
+        MinCostFlowRebalancingStrategyParams minCostFlowRebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
+        minCostFlowRebalancingStrategyParams.targetCoefficientSource = MinCostFlowRebalancingStrategyParams.TargetCoefficientSource.FromZoneAttribute;
+        rebalancingParams.addParameterSet(minCostFlowRebalancingStrategyParams);
+
+        AggregatedMinCostRelocationCalculator relocationCalculator = new AggregatedMinCostRelocationCalculator(new MostCentralDrtZoneTargetLinkSelector(zonalSystem));
+        MinCostFlowRebalancingStrategy strategy = new MinCostFlowRebalancingStrategy(targetCalculator,
+                zonalSystem, createEmptyFleet(), relocationCalculator, rebalancingParams);
+
+        // 3 expected trips in zone 1
+        estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(200, link1, TransportMode.drt));
+        estimator.handleEvent(departureEvent(300, link1, TransportMode.drt));
+        // 1 expected trip in zone 2
+        estimator.handleEvent(departureEvent(100, link2, TransportMode.drt));
+        estimator.reset(1);
+
+        Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
+
+        // 4 vehicles in zone 1 (surplus = 1)
+        List<DvrpVehicle> rebalanceableVehiclesZone1 = new ArrayList<>();
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a1", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a2", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a3", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a4", DvrpVehicle.class), link1));
+        rebalanceableVehicles.put(zone1, rebalanceableVehiclesZone1);
+
+        List<RebalancingStrategy.Relocation> relocations = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations.size()).isEqualTo(1);
+        Assertions.assertThat(relocations.getFirst().link.getId()).isEqualTo(link2.getId());
+
+        rebalanceableVehicles.clear();
+
+        // 5 vehicles in zone 1 (surplus = 2)
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a1", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a2", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a3", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a4", DvrpVehicle.class), link1));
+        rebalanceableVehiclesZone1.add(getDvrpVehicle(Id.create("a5", DvrpVehicle.class), link1));
+        rebalanceableVehicles.put(zone1, rebalanceableVehiclesZone1);
+
+        //set alpha to 2 -> send two vehicles to zone 2
+        zone2.getAttributes().putAttribute(MinCostFlowRebalancingStrategy.REBALANCING_ZONAL_TARGET_ALPHA, 2.);
+        List<RebalancingStrategy.Relocation> relocations2 = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
+        Assertions.assertThat(relocations2.size()).isEqualTo(2);
+        Assertions.assertThat(relocations2.getFirst().link.getId()).isEqualTo(link2.getId());
+        Assertions.assertThat(relocations2.getLast().link.getId()).isEqualTo(link2.getId());
+    }
+
+    private DvrpVehicleImpl getDvrpVehicle(Id<DvrpVehicle> id, Link link) {
+        return new DvrpVehicleImpl(
+                ImmutableDvrpVehicleSpecification.newBuilder()
+                        .id(id)
+                        .capacity(0)
+                        .serviceBeginTime(0)
+                        .serviceEndTime(0)
+                        .startLinkId(link.getId())
+                        .build(), link);
+    }
+
+    private static Fleet createEmptyFleet() {
+        return () -> ImmutableMap.<Id<DvrpVehicle>, DvrpVehicle>builder().build();
+    }
+
+
+    private PreviousIterationDrtDemandEstimator createEstimator() {
+        RebalancingParams rebalancingParams = new RebalancingParams();
+        rebalancingParams.interval = ESTIMATION_PERIOD;
+
+        DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
+        drtConfigGroup.addParameterSet(rebalancingParams);
+
+        return new PreviousIterationDrtDemandEstimator(zonalSystem, drtConfigGroup, ESTIMATION_PERIOD);
+    }
+
+    private PersonDepartureEvent departureEvent(double time, Link link, String mode) {
+        return new PersonDepartureEvent(time, null, link.getId(), mode, mode);
+    }
+
+    static Network createNetwork() {
+        Network network = NetworkUtils.createNetwork();
+        Node a = network.getFactory().createNode(Id.createNodeId("a"), new Coord(0,0));
+        Node b = network.getFactory().createNode(Id.createNodeId("b"), new Coord(500,0));
+        network.addNode(a);
+        network.addNode(b);
+
+        Link ab = network.getFactory().createLink(Id.createLinkId("link_1"), a, b);
+        Link ba = network.getFactory().createLink(Id.createLinkId("link_2"), b, a);
+        network.addLink(ab);
+        network.addLink(ba);
+        return network;
+    }
+}


### PR DESCRIPTION
- **add scenario cutout class with open todos**
- **Finished scenario-cutout (untested)**
- **bind NewScoreAssigner as singleton**
- **scenario cutout resolved null edge cases**
- **update TODOS**
- **change service timeWindow**
- **Bump avro.version from 1.11.3 to 1.12.0**
- **pass money and additionalScore events through to carrierScoringFunction**
- **pass VehicleEnters/LeavesTrafficEvent events through to carrierScoringFunction**
- **inline method**
- **Bump it.unimi.dsi:fastutil from 8.5.13 to 8.5.14**
- **add a test for msa with controller**
- **Bump com.google.protobuf:protobuf-java from 4.27.2 to 4.28.0**
- **prebooking stop: check for expected pickups to prevent pickup and abandonment in the same second**
- **Outsourced VehicleSelection and GetGenerationRates**
- **Implemented Allocator to resolve service duration problem (untested)**
- **feat: DiscreteModeChoiceModule write utilities as an output.**
- **fix: add missing ExtractPlanUtilities class**
- **fix: default value of writeUtilitiesInterval**
- **Removed multithreading and debugged error-values in NetworkChangeEvents**
- **Resolved null error**
- **Fixed jspritIteration value-initialization bug**
- **drt: be less strict with vehicle ids set equality in preplanned scenarios**
- **drt: allow final stay task without requests in preplanned scenarios**
- **fix parking proxy bug**
- **Bump org.apache.commons:commons-lang3 from 3.14.0 to 3.17.0**
- **Bump org.locationtech.jts:jts-core from 1.19.0 to 1.20.0**
- **Bump com.github.luben:zstd-jni from 1.5.6-3 to 1.5.6-5**
- **Bump org.slf4j:slf4j-api from 2.0.13 to 2.0.16**
- **use correct transit modes in pt pseudo network (#3453)**
- **Adding geometry-free zone-system (#3423)**
- **Bump org.apache.commons:commons-compress from 1.26.2 to 1.27.1**
- **Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.3.1 to 3.5.0**
- **Bump org.apache.maven.plugins:maven-install-plugin from 3.1.2 to 3.1.3**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.10.0**
- **revert to old pseudo network creator**
- **Bump com.google.guava:guava from 33.2.1-jre to 33.3.0-jre**
- **use CsvOptions.detectDelimiter instead of hard coded ';' (#3466)**
- **Add individual params model for network freespeed (#3467)**
- **Bump org.codehaus.mojo:buildnumber-maven-plugin from 3.2.0 to 3.2.1**
- **Bump log4j.version from 2.23.1 to 2.24.0**
- **change inputs of class by using globFile**
- **add carrier analysis to small scale commercial generation**
- **drt: add back in max ride time to offer acceptor**
- **dvrp: allow fixed dvrp offline travel time estimation**
- **Bump io.grpc:grpc-all from 1.65.1 to 1.66.0**
- **avoid maven trouble by adding io.opentelemetry-sdk explicitly**
- **feat: allow defining initial link id of vehicle explicitly**
- **Update DvrpConfigGroup.java**
- **Bump io.opentelemetry:opentelemetry-sdk from 1.40.0 to 1.42.1**
- **Bump com.google.errorprone:error_prone_annotations from 2.29.2 to 2.31.0**
- **Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.1 to 3.5.0**
- **format log massages**
- **add more general carrier analysis**
- **clean up**
- **update carrier_stats to new version**
- **update carrier_stats to new version**
- **Bump org.mockito:mockito-core from 5.12.0 to 5.13.0**
- **build(deps-dev): bump net.bytebuddy:byte-buddy from 1.14.18 to 1.15.1**
- **chore: default zoning params**
- **feat: flexibilize structure of drt route constraints (#3479)**
- **Introduce service tasks**
- **Created a viability assurance for carrier plans with small vehicle fleet**
- **Put the carrier-creation back into the main class**
- **Outsourced VehicleSelection**
- **Specified event-classes**
- **build(deps): bump org.apache.maven.plugins:maven-surefire-report-plugin**
- **code review and cleanup**
- **add todos regarding facilities**
- **Add attribute filter to trip analysis (#3486)**
- **Refactored carrier-analysis and created tests**
- **Resolved FileSystemError**
- **drt: add constructor for optimization constraint supplier**
- **add TODO**
- **change pom for freight analysis**
- **add two additional constructors and add separate carriers only analysis**
- **removed copied files to move the original files afterward**
- **update simple tests**
- **make class independent of application contrib**
- **move freight analysis into freight contrib**
- **add buffer try catch**
- **add comments**
- **add number of not handled jobs**
- **formatting**
- **use the current analysis version**
- **use delimiter and add comment**
- **update file for new carrier analysis**
- **update file for new carrier analysis**
- **use configurable delimiter for all classes**
- **build(deps): bump com.google.protobuf:protobuf-java**
- **formatting**
- **change parameters of method**
- **add possible solution for serviceTime selection**
- **add TODO**
- **add different cases for the carriers to add new plans**
- **formatting**
- **renamed variables**
- **add configGroup**
- **add turn restriction test case**
- **add simpler turn restriction test case**
- **renaming, code organization**
- **make addPlan and setSelectedPlan behave according to their name.**
- **make addPlan and setSelectedPlan behave according to their name.**
- **fix test: setPlan as selected (and not only add it)**
- **Implemented the replanning loop (still not fully working)**
- **clean up**
- **add log massages and clean up**
- **simplify and update the population sampling option**
- **clean up**
- **noise: handle activities without coord**
- **restructure commercial specification interface**
- **formatting**
- **rename method**
- **formatting**
- **rename**
- **add current version of solving all carriers**
- **adjust method**
- **use recent method**
- **add method to check if all jobs are handled**
- **also add shipment carrier for testing**
- **comment**
- **use new CarrierUtils method**
- **refactor CleanPopulation (#3496)**
- **Added Javadocs**
- **Added local test setup (only temporary)**
- **Added a converter for xyt csv files to avro**
- **build(deps): bump com.google.errorprone:error_prone_annotations**
- **introduce DashboardUtils for some standardization**
- **Freespeed and facility bugfix**
- **Added tests for full-cutout**
- **Added remaining tests**
- **additional JavaDocs and CheckStyle**
- **Updated reference events file in test**
- **Removed old code/comments**
- **Moved odMatrix, resultingDataPerZone, linksPerZone into class attributes, for smaller method-headers**
- **Javadoc and formatting**
- **Outsourced methods for unhandled-services into UnhandledServicesSolution**
- **minor fixes**
- **Resolved missing TODOs and added facility cutout**
- **revert unintended change**
- **Trip sankey diagram (#3504)**
- **write edge attributes from sumo into the features csv (#3508)**
- **Transit Viewer Dashboard - Custom Route Types (#3507)**
- **allow for Controller with double l**
- **fix cadyts memory leak (#3512)**
- **fix: considering the case when current element is a leg when aborting rejected prebooking. (#3505)**
- **chore(drt:PlusOneRebalancingStrategy): checking that target link id exists (#3503)**
- **fix glob patterns in dashboards for runs without run id (#3515)**
- **support different crs and add some error checking (#3517)**
- **typical vehicle categories for noise analysis**
- **updates tests for freight analysis to use more example inputs**
- **formatting**
- **reduce iterations for test**
- **try to fix test**
- **remove usage of path to fix tests**
- **use new analysis version**
- **Add matsim.tempDir property for specifying ImageIO cache directory**
- **Move specification of MATSim temp dir to OutputDirectoryHierarchy**
- **Add test case**
- **Assert that matsimTempDir is not null**
- **update test for both model types**
- **change serviceTimeSelection and remove from interface**
- **Additional transit schedule validations (#3524)**
- **build(deps): bump com.google.protobuf:protobuf-java**
- **Avoid creating unnecessary travel time calculators (#3525)**
- **clean up**
- **Add tests for storage capacity under queue and kinematicWaves traffic dynamics (#3533)**
- **Fix PtScoringTest on Windows**
- **solve windows related problems in drt-extensions-tests**
- **interpret person specific asc as offset in addition to the subpopulation's asc (#3537)**
- **change output dir**
- **Extend trip analysis (#3540)**
- **Consider stationary agents in scenario cut-out (#3541)**
- **use files from main output directory instead of from last iteration**
- **fix some edge cases when routing on networks with turn restrictions**
- **improve consistency checks (#3547)**
- **add exception in certain situations**
- **TODO comment**
- **update service time selection**
- **formatting**
- **Inline xml writing into Event class (#3539)**
- **Don't assume car network mode as default (#3532)**
- **add qsim modes to default traffic dashboard (#3551)**
- **compute noise damages only for activities that are inside the specified grid**
- **carry on stopAreaId to derived TransitStopFacilities and set stopAreaId to the original TransitStopFacility when not present yet (#3554)**
- **defaults for networkModesToIgnore + consistency checks/warnings**
- **Add more linktypes to the SUMO converter (#3559)**
- **add networkMode to defaultVehicleType (#3560)**
- **use fix output names for analysis**
- **Pt pax volumes into pt dashboard (#3552)**
- **update default vehicleTypes incl. HBEFA categories and updated costs**
- **feat: make chargers attributable (#3565)**
- **feat: generalize multimodal link chooser (#3536)**
- **flush only at the end**
- **introduce now necessary network mode to generated vehicles**
- **Deprecate withHoles options for 'TrafficDynamics'. Also, we have deprecated everything except INFLOW_FROM_FDIAG in InflowCapacitySetting**
- **feat(dvrp): cached free-speed matrices (#3567)**
- **Update pom.xml**
- **update log massage**
- **rename method**
- **rename method**
- **add configurable implementation of job duration calculation**
- **update method of cutting jobs in possible parts**
- **update combineJobs method and ad related test**
- **Fix: Non-deterministic behaviour of SwissRailRaptor (#3568)**
- **relocate method**
- **update interface and implementation**
- **Improve SquareGridZoneSystem performance**
- **Bugfix**
- **add min cost flow test plus option of setting target sensitivity alpha and beta per zone**
